### PR TITLE
feat: Add author profile section below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+import { AuthorProfile } from 'app/components/author-profile'
+import authorData from 'app/data/author.json'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -79,7 +81,8 @@ export default async function Blog({ params }) {
             url: `${baseUrl}/blog/${post.slug}`,
             author: {
               '@type': 'Person',
-              name: 'My Portfolio',
+              name: authorData.name,
+              url: baseUrl,
             },
           }),
         }}
@@ -95,6 +98,11 @@ export default async function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        name={authorData.name}
+        bio={authorData.bio}
+        avatar={authorData.avatar}
+      />
     </section>
   )
 }

--- a/app/components/author-profile.tsx
+++ b/app/components/author-profile.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image'
+
+interface AuthorProfileProps {
+  name: string
+  bio: string
+  avatar: string
+}
+
+export function AuthorProfile({ name, bio, avatar }: AuthorProfileProps) {
+  return (
+    <div className="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+      <div className="flex items-start gap-4">
+        <div className="relative w-16 h-16 flex-shrink-0">
+          <Image
+            src={avatar}
+            alt={`${name} avatar`}
+            width={64}
+            height={64}
+            className="rounded-full"
+            priority={false}
+          />
+        </div>
+        <div className="flex flex-col">
+          <h3 className="font-semibold text-lg text-neutral-900 dark:text-neutral-100">
+            {name}
+          </h3>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            {bio}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/data/author.json
+++ b/app/data/author.json
@@ -1,0 +1,9 @@
+{
+  "name": "심지은",
+  "bio": "AI와 함께 성장하는 개발자입니다.",
+  "avatar": "/images/avatar.jpg",
+  "social": {
+    "github": "https://github.com/simjieun",
+    "email": "your.email@example.com"
+  }
+}


### PR DESCRIPTION
## Summary
게시글 본문 하단에 작가 프로필 섹션을 추가하여 독자들에게 더 개인적인 느낌을 제공합니다.

- 작가 정보 데이터 파일 추가 (`app/data/author.json`)
- 작가 프로필 컴포넌트 생성 (아바타 이미지, 이름, 짧은 소개)
- 블로그 상세 페이지에 AuthorProfile 컴포넌트 통합
- SEO 개선: JSON-LD author 필드를 동적 데이터로 업데이트

## Test plan
- [ ] 빌드 성공 확인 (`npm run build`)
- [ ] 블로그 게시글 페이지에서 작가 프로필 섹션 표시 확인
- [ ] 다크모드 전환 시 스타일 정상 작동 확인
- [ ] 모바일/데스크톱 반응형 레이아웃 확인
- [ ] TypeScript 타입 에러 없음 확인

Closes #2